### PR TITLE
Remove Twitter image button from sign in page

### DIFF
--- a/app/src/main/java/reverieworks/addy/Fragment/SignIn.java
+++ b/app/src/main/java/reverieworks/addy/Fragment/SignIn.java
@@ -60,7 +60,6 @@ public class SignIn extends Fragment implements GoogleApiClient.OnConnectionFail
     private EditText editText_password;
     private ImageView imageView_facebookLogIn;
     private ImageView imageView_GoogleLogIn;
-    private ImageView imageView_TwitterLogIn;
     private Button button_signIn;
     private FirebaseAuth mAuth;
     private FirebaseAuth.AuthStateListener mAuthListener;
@@ -245,39 +244,8 @@ public class SignIn extends Fragment implements GoogleApiClient.OnConnectionFail
             }
         });
 
-        //Twitter LogIn
-        imageView_TwitterLogIn = (ImageView) view.findViewById(R.id.imageView_TwitterLogo_signIn);
-        imageView_TwitterLogIn.setOnTouchListener(new View.OnTouchListener() {
-            @Override
-            public boolean onTouch(View v, MotionEvent event) {
-
-                switch (event.getAction()) {
-
-                    case MotionEvent.ACTION_DOWN: {
-
-                        //overlay is black with transparency of 0x77 (119)
-                        imageView_TwitterLogIn.setColorFilter(0x77000000, PorterDuff.Mode.SRC_ATOP);
-                        imageView_TwitterLogIn.invalidate();
-
-                        twitterLogIn();
-                        break;
-                    }
-                    case MotionEvent.ACTION_UP: {
-                        imageView_TwitterLogIn.clearColorFilter();
-                        imageView_TwitterLogIn.invalidate();
-                        break;
-                    }
-                }
-                return true;
-            }
-        });
-
         // Inflate the layout for this fragment
         return view;
-    }
-
-    private void twitterLogIn() {
-
     }
 
     private void facebookLogIn(View view) {

--- a/app/src/main/res/layout/fragment_sign_in.xml
+++ b/app/src/main/res/layout/fragment_sign_in.xml
@@ -157,12 +157,14 @@
                         <LinearLayout
                             android:orientation="horizontal"
                             android:layout_width="match_parent"
-                            android:layout_height="wrap_content">
+                            android:layout_height="wrap_content"
+                            android:paddingBottom="30dp">
 
                             <LinearLayout
                                 android:orientation="vertical"
                                 android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"
+                                android:gravity="center"
                                 android:layout_weight="1">
 
                                 <ImageView
@@ -182,28 +184,11 @@
                                     android:layout_marginBottom="30dp" />
                             </LinearLayout>
 
-
                             <LinearLayout
                                 android:orientation="vertical"
                                 android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"
-                                android:layout_weight="1">
-
-                                <ImageView
-                                    android:layout_width="wrap_content"
-                                    android:layout_height="wrap_content"
-                                    android:src="@drawable/twitter_logo"
-                                    android:background="@null"
-                                    android:padding="10dp"
-                                    android:id="@+id/imageView_TwitterLogo_signIn"/>
-
-                            </LinearLayout>
-
-
-                            <LinearLayout
-                                android:orientation="vertical"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
+                                android:gravity="center"
                                 android:layout_weight="1">
 
                                 <ImageView


### PR DESCRIPTION
Fixes #9

#### Checklist


- [x] My branch is up-to-date with the Upstream `master` branch.
- [x] I have added necessary documentation (if appropriate)



**Changes proposed in this pull request**
- Remove Twitter image button from sign in screen
- Add 30dp padding to bottom of containing layout of social sign in buttons to keep buttons from touching bottom of screen

**Screenshots** 

Before: 
![device-2017-10-11-070531](https://user-images.githubusercontent.com/12868228/31440852-f6e183f6-ae56-11e7-848b-15c2e53ab523.png)

After:
![device-2017-10-11-071515](https://user-images.githubusercontent.com/12868228/31440855-f97861a2-ae56-11e7-8316-1a9dfad70bcc.png)

**Closes #9 **
